### PR TITLE
feat(cert-manager): update checksum logic and improve CLI architectur…

### DIFF
--- a/roles/cert-manager/tasks/facts.yaml
+++ b/roles/cert-manager/tasks/facts.yaml
@@ -23,8 +23,8 @@
   ansible.builtin.set_fact:
     certmanager_project:
       release:
-        checksum: "{{ certmanager_map.release.url }}/{{ certmanager_vars.release.checksum | basename }}"
-        file: "cmctl_{{ cli_arch | default('unknown') }}_{{ cli_arch | default('unknown') }}"
+        checksum: "{{ certmanager_map.release.url }}/checksums.txt"
+        file: "cmctl_{{ cli_os | default('linux') }}_{{ cli_arch | default('amd64') }}"
         url: "{{ certmanager_map.release.url }}"
       tag: "{{ certmanager_vars.kubernetes.helm.chart.version }}"
 

--- a/roles/cert-manager/tasks/main.yaml
+++ b/roles/cert-manager/tasks/main.yaml
@@ -10,6 +10,7 @@
 
     - name: Validate service state
       ansible.builtin.wait_for:
+        host: "{{ k3s_map.cluster.dns }}"
         port: "{{ k3s_vars.server.api.port }}"
         state: drained
         timeout: 30
@@ -25,16 +26,15 @@
 
     - name: Set sha256 checksum fact
       ansible.builtin.set_fact:
-        sha256_checksum: "{{ item.split(' ')[0] }}"
-      loop: "{{ checksums.content.split('\n') }}"
-      when:
-        - item | regex_search(certmanager_vars.release.file + '$')
-        - item | regex_search('/' + certmanager_vars.release.file + '$')
+        sha256_checksum: "{{ item.split()[0] }}"
+      loop: "{{ checksums.content.splitlines() }}"
+      when: item.split()[1] == certmanager_vars.release.file
       run_once: true
+
 
     - name: Set cmctl download URL
       ansible.builtin.set_fact:
-        cmctl_download_url: "{{ certmanager_project.release.url }}/cmctl_{{ cli_os | default('unknown') }}_{{ cli_arch | default('unknown') }}"
+        cmctl_download_url: "{{ certmanager_project.release.url }}/{{ certmanager_vars.release.file }}"
 
     - name: Check if cmctl is already installed
       ansible.builtin.stat:
@@ -54,14 +54,14 @@
       retries: 5
       delay: 5
       until: download_result is succeeded
-      failed_when: download_result.failed and download_result.retries >= 5
+      failed_when: download_result.failed
 
     - name: Move and rename cmctl binary to bin directory
       ansible.builtin.command:
-        cmd: mv /tmp/"{{ cmctl_download_url.split('/')[-1] }}" "{{ certmanager_vars.bin_directory }}/cmctl"
+        cmd: mv /tmp/cmctl "{{ certmanager_vars.bin_directory }}/cmctl"
       when: download_result is succeeded
       register: move_result
-
+      
     - name: Create symlink for cmctl
       ansible.builtin.file:
         path: "{{ certmanager_vars.bin_directory }}/kubectl-cert_manager"
@@ -79,12 +79,6 @@
         - ansible_check_mode
         - not cmctl_stat.stat.exists
 
-    - name: Add Jetstack Helm repository
-      kubernetes.core.helm_repository:
-        name: jetstack
-        repo_url: '{{ certmanager_vars.kubernetes.helm.repository.url }}'
-        state: present
-
     - name: Chart Setup
       run_once: true
       block:
@@ -95,8 +89,8 @@
 
         - name: Add Jetstack Helm repository
           kubernetes.core.helm_repository:
-            name: cert-manager
-            repo_url: "https://charts.jetstack.io"
+            name: jetstack
+            repo_url: '{{ certmanager_vars.kubernetes.helm.repository.url }}'
             state: present
 
         - name: Install cert-manager

--- a/roles/coredns/tasks/main.yaml
+++ b/roles/coredns/tasks/main.yaml
@@ -9,6 +9,7 @@
   block:
     - name: Validate service state
       ansible.builtin.wait_for:
+        host: "{{ k3s_map.cluster.dns }}"
         port: "{{ k3s_vars.server.api.port }}"
         state: drained
         timeout: 30

--- a/roles/external-dns/tasks/main.yaml
+++ b/roles/external-dns/tasks/main.yaml
@@ -11,6 +11,7 @@
   block:
     - name: Validate service state
       ansible.builtin.wait_for:
+        host: "{{ k3s_map.cluster.dns }}"
         port: '{{ k3s_vars.server.api.port }}'
         state: drained
         timeout: 30


### PR DESCRIPTION
…e handling

- Updated checksum URL to use `checksums.txt` and refined file naming for CLI architecture detection.
- Improved service state validation by adding host configuration for `wait_for` tasks.
- Enhanced checksum parsing with simplified logic using `splitlines()` and `item.split()`.
- Adjusted cmctl download URL construction to align with refined file handling.
- Removed redundant Helm repository addition and refactored Helm setup block for clarity.

fix(cert-manager): corrected `failed_when` condition for retries in download tasks.

feat(coredns, external-dns): added host configuration for service state validation tasks.

# Proposed Changes
<!--- Provide a general summary of your changes -->

-
-
-

## Checklist

- [ ] Tested locally
- [ ] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [ ] Did not add any unnecessary changes
- [ ] Ran pre-commit install at least once before committing
- [ ] 🚀
